### PR TITLE
ad-hoc patch to enable dynamic compiling.

### DIFF
--- a/lib/js/core.coffee
+++ b/lib/js/core.coffee
@@ -116,18 +116,20 @@ _layouts =
   '.robustness-diagram': _new_layout "RobustnessDiagramLayout"
 
 _runScripts = ->
-  return null if _runScripts.done
   scripts = document.getElementsByTagName 'script'
   diagrams = (s for s in scripts when s.type.match /text\/jumly+(.*)/)
   for script in diagrams
-    _evalHTMLScriptElement script
-  _runScripts.done = true
+    unless $(script).data 'jumly-evaluated'
+      _evalHTMLScriptElement script
+      $(script).data 'jumly-evaluated', true
   #$("body").trigger $.Event("ran.jumly")
   null
 
 # Listen for window load, both in browsers and in IE.
 unless core.env.is_node
-  if window.addEventListener
+  if typeof $ isnt 'undefined'
+    $(window).on 'DOMContentLoaded', _runScripts
+  else if window.addEventListener
     window.addEventListener 'DOMContentLoaded', _runScripts
   else
     throw "window.addEventListener is not supported"


### PR DESCRIPTION
Currently jumly compiles just one time, right after page loaded.
We have a document rendering tool which generates DOM tree dynamically.
On integrating with jumly(it's an awesome product!), we need to compile jumly scripts in documents dynamically, too.

_I think_ the patch is does not have a best solution. Exporting a public API would be better.
You can reject this and make your own patch. Anyway what we hope is to have a dynamic compilation feature.
Cheers :)
